### PR TITLE
Change portainer ip

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
@@ -25,7 +25,7 @@
 #
 
 status=$(/sbin/e-smith/config getprop docker status)
-IpAddress=172.28.0.2
+IpAddress=172.28.255.254
 
 if [[ ${status} != enabled ]]; then
     exit 0

--- a/root/etc/httpd/admin-conf.d/portainer.conf
+++ b/root/etc/httpd/admin-conf.d/portainer.conf
@@ -4,10 +4,10 @@
 </IfModule>
 
 <Location /portainer/>
-    ProxyPass  http://172.28.0.2:9000/
-    ProxyPassReverse http://172.28.0.2:9000/
+    ProxyPass  http://172.28.255.254:9000/
+    ProxyPassReverse http://172.28.255.254:9000/
 </Location>
 
 <Location /portainer/api/websocket/> 
-    ProxyPass ws://172.28.0.2:9000/api/websocket/
+    ProxyPass ws://172.28.255.254:9000/api/websocket/
 </Location>


### PR DESCRIPTION
Portainer and docker has changed and now if you do not set a fixed IP  you could have two containers with the same IP in the acqua network. When you use the template system of portainer, you create your containers with a dhcp like, the IP are attributed container after container, but after the reboot, the IP of portainer could be used by another container(docker do not probe if the IP is free).

If we use the last IP of the network we have less risk to see the IP of portainer used by another container 