### PR TITLE
Open ports to FW zone

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/66DockRules
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/66DockRules
@@ -1,0 +1,22 @@
+{
+    use esmith::ConfigDB;
+    my $dock = esmith::ConfigDB->open_ro('/var/lib/nethserver/db/dockrules')
+                        || esmith::ConfigDB->create('/var/lib/nethserver/db/dockrules');
+
+    foreach my $rule ($dock->get_all_by_prop('status' => 'enabled')) {
+        my $name      = $rule->key;
+        my $network   =   $rule->prop('type') || '';
+        my $tcpPorts  = $rule->prop(TCPPorts) || $rule->prop(TCPPort) || '';
+        my $udpPorts  = $rule->prop(UDPPorts) || $rule->prop(UDPPort) || '';
+
+        if($tcpPorts || $udpPorts) {
+            $OUT .= "# Rule for docker $name\n";
+            foreach my $port (split(',', $tcpPorts)) {
+                $OUT .= "ACCEPT\t$network\t\$FW\ttcp\t$port\n";
+            }
+            foreach my $port (split(',', $udpPorts)) {
+                $OUT .= "ACCEPT\t$network\t\$FW\tudp\t$port\n";
+            }
+        }
+    }
+}


### PR DESCRIPTION
We could open to the firewall zone from aqua like this, all other cases are NOT covered

loc to aqua
net to aqua
aqua to loc

```
db dockrules set custom aqua TCPPort 12,23,56,89 UDPPorts 12,23,56,89 status enabled
signal-event firewall-adjust
```
I am not sure if we need to make two props more to specify the source and the destination, like this we could cover any case

something like this 

`db dockrules set custom rule source net destination aqua TCPPort 12,23,56,89 UDPPorts 12,23,56,89 status enabled`

what do you think  ?