### PR TITLE
Add bridged docker network Aeria

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ credentials.
 Docker repository
 -----------------
 
-The official repository of docker could be enabled to test the lastest version ::
+The official repository of docker could be enabled to test the latest version ::
 
     yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     
@@ -86,3 +86,25 @@ For testing purposes you can open the docker network by policy. In a production 
   loc aqua ACCEPT
   EOF
   signal-event firewall-adjust
+
+Aeria network
+-------------
+
+NethServer docker provides a docker network named Aeria that is bound to a bridge.
+For bridge creation the server manager could be used.
+
+To enable the Aeria network the bridgeAeria db prop has to be set to the name of the bridge ::
+
+  config setprop docker bridgeAeria br0
+  signal-event nethserver-docker-update
+
+The NethServer DHCP module can be used to set IP addresses for the docker containers.
+By default docker containers use random MAC addresses so fixed ones need to be set for the containers to make DHCP reservations work.
+
+Here is an example for starting pihole in the Aeria network and set the MAC address ::
+
+  docker run -d --name pihole --net=aeria --mac-address=01:02:03:04:05:06 pihole/pihole:latest
+
+Aeria uses a docker plugin. To update the plugin ::
+
+  signal-event nethserver-docker-plugin-update

--- a/createlinks
+++ b/createlinks
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 #
-# Copyright (C) 2018 Nethesis S.r.l.
+# Copyright (C) 2020 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -33,9 +33,17 @@ event_actions('nethserver-docker-update', qw(
     initialize-default-databases   00
     nethserver-docker-create-network 20
     nethserver-docker-create-portainer 20
+    nethserver-docker-create-aeria 20
 ));
 event_services('nethserver-docker-update', qw(
     docker restart
     httpd-admin reload
 ));
 
+#
+# event nethserver-docker-plugin-update event
+#
+event_actions('nethserver-docker-plugin-update', qw(
+    initialize-default-databases   00
+    nethserver-docker-upgrade-plugin 20
+));

--- a/root/etc/e-smith/events/actions/nethserver-docker-create-aeria
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-aeria
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Check if aeria network does not exist and the bridge is set, install the net-dhcp plugin and create the docker aeria network
+#
+
+bridge=$(/sbin/e-smith/config getprop docker bridge)
+
+if [[ -z ${bridge} ]]; then
+    exit 0
+fi
+
+HasNetwork=$(docker network ls -f name=aeria -q)
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+
+docker plugin install --grant-all-permissions devplayer0/net-dhcp
+
+if [[ -n ${HasNetwork} ]]; then
+    exit 0
+fi
+
+echo "[NOTICE] Creating the aeria Docker network..."
+docker network create -d devplayer0/net-dhcp:latest --ipam-driver null -o bridge=${bridge} aeria

--- a/root/etc/e-smith/events/actions/nethserver-docker-create-aeria
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-aeria
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2018 Nethesis S.r.l.
+# Copyright (C) 2020 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -24,9 +24,9 @@
 # Check if aeria network does not exist and the bridge is set, install the net-dhcp plugin and create the docker aeria network
 #
 
-bridge=$(/sbin/e-smith/config getprop docker bridge)
+bridgeAeria=$(/sbin/e-smith/config getprop docker bridgeAeria)
 
-if [[ -z ${bridge} ]]; then
+if [[ -z ${bridgeAeria} ]]; then
     exit 0
 fi
 
@@ -42,4 +42,4 @@ if [[ -n ${HasNetwork} ]]; then
 fi
 
 echo "[NOTICE] Creating the aeria Docker network..."
-docker network create -d devplayer0/net-dhcp:latest --ipam-driver null -o bridge=${bridge} aeria
+docker network create -d devplayer0/net-dhcp:latest --ipam-driver null -o bridge=${bridgeAeria} aeria

--- a/root/etc/e-smith/events/actions/nethserver-docker-upgrade-plugin
+++ b/root/etc/e-smith/events/actions/nethserver-docker-upgrade-plugin
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2018 Nethesis S.r.l.
+# Copyright (C) 2020 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -24,9 +24,9 @@
 # Upgrade net-dhcp plugin if aeria is enabled and bridge exists
 #
 
-bridge=$(/sbin/e-smith/config getprop docker bridge)
+bridgeAeria=$(/sbin/e-smith/config getprop docker bridgeAeria)
 
-if [[ -z ${bridge} ]]; then
+if [[ -z ${bridgeAeria} ]]; then
     exit 0
 fi
 

--- a/root/etc/e-smith/events/actions/nethserver-docker-upgrade-plugin
+++ b/root/etc/e-smith/events/actions/nethserver-docker-upgrade-plugin
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Upgrade net-dhcp plugin if aeria is enabled and bridge exists
+#
+
+bridge=$(/sbin/e-smith/config getprop docker bridge)
+
+if [[ -z ${bridge} ]]; then
+    exit 0
+fi
+
+docker plugin disable devplayer0/net-dhcp;docker plugin rm devplayer0/net-dhcp;docker plugin install --grant-all-permissions devplayer0/net-dhcp


### PR DESCRIPTION
I added two actions and the db prop bridge for the docker service:

* nethserver-docker-create-aeria - installs the plugin and creates the network when db prop bridge exists
* nethserver-docker-upgrade-plugin - upgrades the plugin

Feel free to add an event, I can do it tomorrow evening...