### PR TITLE
Test if containers are up for shorewall rules

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/50docker
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/50docker
@@ -4,6 +4,10 @@
 {
    use JSON;
 
+  # test if containers are running, exit if false
+  my $output = `docker ps  --format='{{ .Names }}'`;
+  exit 0 if ($output eq '');
+
    open(PH, '-|', "docker inspect --format='{{json .}}' `docker ps  --format='{{ .Names }}'`");
 
    $OUT = '';
@@ -28,5 +32,3 @@
    close(PH);
 
 }
-
-


### PR DESCRIPTION
Traces in logs during event `firewall-adjust`
```
May 15 20:03:10 ns7loc15 esmith::event[5185]: expanding /etc/shorewall/rules
May 15 20:03:11 ns7loc15 esmith::event[5185]: "docker inspect" requires at least 1 argument.
May 15 20:03:11 ns7loc15 esmith::event[5185]: See 'docker inspect --help'.
May 15 20:03:11 ns7loc15 esmith::event[5185]: 
May 15 20:03:11 ns7loc15 esmith::event[5185]: Usage:  docker inspect [OPTIONS] NAME|ID [NAME|ID...]
May 15 20:03:11 ns7loc15 esmith::event[5185]: 
May 15 20:03:11 ns7loc15 esmith::event[5185]: Return low-level information on Docker objects
```