### PR TITLE
After docker service restart, portainer cannot connect to the endpoint

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -34,7 +34,7 @@ event_actions('nethserver-docker-update', qw(
     nethserver-docker-create-logs  10
     nethserver-docker-enable-repository 10
     nethserver-docker-create-network 20
-    nethserver-docker-create-portainer 20
+    nethserver-docker-create-portainer 95
     nethserver-docker-create-aeria 20
     nethserver-docker-macvlan-creation 20
 ));

--- a/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
@@ -54,4 +54,5 @@ docker run --detach \
     --hostname portainer \
     --network aqua \
     --ip ${IpAddress} \
-    portainer/portainer
+    portainer/portainer \
+    -H unix:///var/run/docker.sock

--- a/root/etc/systemd/system/docker.service.d/nethserver.conf
+++ b/root/etc/systemd/system/docker.service.d/nethserver.conf
@@ -7,3 +7,4 @@ PartOf=network.service
 ExecStart=
 ExecStart=/usr/bin/dockerd --config-file=/etc/docker/docker.conf
 ExecStartPost=/usr/libexec/dockerCreateMacVlan0
+ExecStartPost=/usr/libexec/dockerRestartPortainer

--- a/root/usr/libexec/dockerCreateMacVlan0
+++ b/root/usr/libexec/dockerCreateMacVlan0
@@ -34,6 +34,11 @@ fi
 /usr/sbin/ip addr add $macVlanNetwork dev macvlan0
 /usr/sbin/ip link set macvlan0 up
 
+if ! /usr/bin/docker ps &>/dev/null; then
+    echo "[WARNING] docker is down, Exit"
+    exit 0
+fi
+
 #
 # restart the docker container on macvlan. Needed after network.service restart or interface-update event
 #

--- a/root/usr/libexec/dockerRestartPortainer
+++ b/root/usr/libexec/dockerRestartPortainer
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#
+# When docker is restarted Portainer cannot use the local endpoint unix:///var/run/docker.sock
+#
+
+HasPortainer=$(docker ps -f name=portainer -q -a)
+
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+
+if [[ -z ${HasPortainer} ]]; then
+    exit 0
+fi
+
+/usr/bin/docker restart portainer

--- a/root/usr/libexec/dockerRestartPortainer
+++ b/root/usr/libexec/dockerRestartPortainer
@@ -4,8 +4,8 @@
 # When docker is restarted Portainer cannot use the local endpoint unix:///var/run/docker.sock
 #
 
-if ! systemctl is-active -q docker; then
-    echo "[WARNING] docker is down, exit"
+if ! /usr/bin/docker ps &>/dev/null; then
+    echo "[WARNING] docker is down, Exit"
     exit 0
 fi
 

--- a/root/usr/libexec/dockerRestartPortainer
+++ b/root/usr/libexec/dockerRestartPortainer
@@ -4,6 +4,11 @@
 # When docker is restarted Portainer cannot use the local endpoint unix:///var/run/docker.sock
 #
 
+if ! systemctl is-active -q docker; then
+    echo "[WARNING] docker is down, exit"
+    exit 0
+fi
+
 HasPortainer=$(docker ps -f name=portainer -q -a)
 
 if [[ $? != 0 ]]; then


### PR DESCRIPTION
This PR intends to 
- create directly portainer to use the local endpoint  unix:///var/run/docker.sock
- After a docker service restart, portainer cannot connect to the local endpoint, we need to restart portainer to connect again on this endpoint. 


after a `systemctl restart docker` When I use portainer, it complains that the local endpoint is not reachable