### PR TITLE
Contact of aeria developer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,8 @@ Aeria uses a docker plugin. To update the plugin ::
 
     signal-event nethserver-docker-plugin-update
 
+The aeria network is not standard on docker, the developer can be contacted at https://github.com/devplayer0/docker-net-dhcp
+
 
 Macvlan
 -------


### PR DESCRIPTION
Added the contact of aeria developer because `docker-net-dhcp` is not a standard network