### PR TITLE
The bridge cannot be shared among aeria and macvlan

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Aeria network
 -------------
 
 NethServer docker provides a docker network named Aeria that is bound to a bridge.
-For bridge creation the server manager could be used.
+For bridge creation the server manager could be used. The same bridge cannot be shared among ``aeria`` and ``macvlan``, it is a docker limitation.
 
 To enable the Aeria network the bridgeAeria db prop has to be set to the name of the bridge ::
 
@@ -131,7 +131,7 @@ The difference between macvlan and aeria is that macvlan is not a plugin, it is 
 
 NethServer docker provides a docker network named ``macvlan`` that must be bound to a bridge. Each container on the network ``macvlan`` must have a relevant IP in the range assigned to macvlan, all containers will communicate like any servers on your network.
 
-For the bridge creation the server manager could be used, if you have already installed the account provider Samba AD (nethserver-dc), you have already a bridge called ``br0``. 
+For the bridge creation the server manager could be used, if you have already installed the account provider Samba AD (nethserver-dc), you have already a bridge called ``br0``. The same bridge cannot be shared among ``aeria`` and ``macvlan``, it is a docker limitation.
 
 
 A bridge is mandatory to ``macvlan``, you must accomplish this step before to go further: ``ip a`` can valid that the bridge is up and workable

--- a/root/etc/e-smith/events/actions/nethserver-docker-create-aeria
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-aeria
@@ -25,8 +25,14 @@
 #
 
 bridgeAeria=$(/sbin/e-smith/config getprop docker bridgeAeria)
+macVlanNic=$(/sbin/e-smith/config getprop docker macVlanNic)
 
 if [[ -z ${bridgeAeria} ]]; then
+    exit 0
+fi
+
+if [[ ${bridgeAeria} == ${macVlanNic} ]]; then
+    echo "[NOTICE] The macvlan and aeria network cannot share the same bridge"
     exit 0
 fi
 

--- a/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2018 Nethesis S.r.l.
+# Copyright (C) 2020 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.

--- a/root/etc/e-smith/events/actions/nethserver-docker-enable-repository
+++ b/root/etc/e-smith/events/actions/nethserver-docker-enable-repository
@@ -1,4 +1,24 @@
- ￼#!/bin/bash
+#!/bin/bash
+
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
 
 echo '[NOTICE] applying new YUM repository configuration'
 exec /sbin/e-smith/signal-event software-repos-save

--- a/root/etc/e-smith/events/actions/nethserver-docker-interface-update-restart-docker
+++ b/root/etc/e-smith/events/actions/nethserver-docker-interface-update-restart-docker
@@ -1,6 +1,26 @@
 #!/bin/bash
 
 #
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
 # Restart docker after the event interface-update
 #
 

--- a/root/etc/e-smith/events/actions/nethserver-docker-macvlan-creation
+++ b/root/etc/e-smith/events/actions/nethserver-docker-macvlan-creation
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
 macVlanNic=$(/usr/sbin/e-smith/db configuration getprop docker macVlanNic)
 macVlanGateway=$(/usr/sbin/e-smith/db configuration getprop docker macVlanGateway)
 macVlanLocalNetwork=$(/usr/sbin/e-smith/db configuration getprop docker macVlanLocalNetwork)

--- a/root/etc/e-smith/events/actions/nethserver-docker-macvlan-creation
+++ b/root/etc/e-smith/events/actions/nethserver-docker-macvlan-creation
@@ -3,6 +3,7 @@
 macVlanNic=$(/usr/sbin/e-smith/db configuration getprop docker macVlanNic)
 macVlanGateway=$(/usr/sbin/e-smith/db configuration getprop docker macVlanGateway)
 macVlanLocalNetwork=$(/usr/sbin/e-smith/db configuration getprop docker macVlanLocalNetwork)
+bridgeAeria=$(/sbin/e-smith/config getprop docker bridgeAeria)
 
 # Check if macvlan network does not exist, and attempt to create it as necessariy
 #
@@ -49,6 +50,11 @@ fi
 isBridge=$(/usr/sbin/e-smith/db networks gettype $macVlanNic)
 if [[ $isBridge != 'bridge' ]];then
     echo "The nic is not a bridge, macvlan cannot be created"
+    exit 0
+fi
+
+if [[ ${bridgeAeria} == ${macVlanNic} ]]; then
+    echo "[NOTICE] The macvlan and aeria network cannot share the same bridge"
     exit 0
 fi
 


### PR DESCRIPTION
We face a docker limitation, docker doesn't accept to create a network on a bridge already used by a previous network. It creates a conflict.

In short if `br0` is already used by aeria, then macvlan cannot be created on `br0`