### PR TITLE
Add  TCP 443 for portainer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ More port rules can be opened to the system services with a esmith db command::
 
 * It exposes portainer dashboards through the
   ``httpd-admin`` Apache instance as ``https://<IP>:980/portainer/``
+  ``httpd`` Apache instance as ``https://<IP>/portainer/``
 
 The default Docker *bridged* network is enabled
 
@@ -57,9 +58,11 @@ Portainer is an interface to manage all containers running on this host or event
     config setprop portainer status enabled
     signal-event nethserver-docker-update
 
-Access the Portainer user interface at ::
+Access the Portainer user interface 443 or 980 TCP port::
 
     https://<IP>:980/portainer/
+    https://<IP>/portainer/
+
 
 The first time it is accessed, it asks to generate the administrative
 credentials.

--- a/createlinks
+++ b/createlinks
@@ -28,6 +28,8 @@ use esmith::Build::CreateLinks  qw(:all);
 #
 event_templates('nethserver-docker-update', qw(
     /etc/docker/docker.conf
+    /etc/httpd/conf.d/default-virtualhost.inc
+    /etc/httpd/conf.d/zzz_portainer.conf
 ));
 event_actions('nethserver-docker-update', qw(
     initialize-default-databases   00
@@ -41,6 +43,7 @@ event_actions('nethserver-docker-update', qw(
 event_services('nethserver-docker-update', qw(
     docker restart
     httpd-admin reload
+    httpd reload
 ));
 
 #

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/default-virtualhost.inc/60Portainer
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/default-virtualhost.inc/60Portainer
@@ -1,0 +1,7 @@
+#
+#60portainer
+#
+{
+  $OUT .= " RewriteEngine On\n";
+  $OUT .= " RewriteRule ^/portainer(/.*|\$)    https://%{HTTP_HOST}/portainer/\$1 [L,R]\n";
+}

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_portainer.conf/01localAccessString
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_portainer.conf/01localAccessString
@@ -1,0 +1,17 @@
+{
+    #---------------------------------------------------------------------
+    # Grab ValidFrom access list property of httpd-admin
+    # SSL enabled virtual hosts should only allow access from IP's in
+    # this list, as well as local networks.
+    #---------------------------------------------------------------------
+    use esmith::NetworksDB;
+
+    my $ndb = esmith::NetworksDB->open_ro();
+
+    my @localAccess = $ndb->local_access_spec();
+    $localAccess .= join ' ',
+	map { s:/255.255.255.255::; $_ }
+	    @localAccess;
+
+    "";
+}

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_portainer.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zzz_portainer.conf/10base
@@ -1,0 +1,15 @@
+<IfModule rewrite_module>
+    RewriteEngine on
+    RewriteRule ^/portainer$ /portainer/ [R]
+</IfModule>
+
+<Location /portainer/>
+    ProxyPass  http://172.28.255.254:9000/
+    ProxyPassReverse http://172.28.255.254:9000/
+    Require ip {{$localAccess}}
+</Location>
+
+<Location /portainer/api/websocket/> 
+    ProxyPass ws://172.28.255.254:9000/api/websocket/
+    Require ip {{$localAccess}}
+</Location>


### PR DESCRIPTION
Nethgui is obsoleted in 7.9, we now have to use either another port or require the installation of nethgui. I would vote for to use currently the usage of 980 and 443, for the next version we could remove 980.

I did a redirection to https if you use the port 80 and a Require only to the local network, if you use portainer from an external IP, then you are forbidden by apache.