### PR TITLE
Requires nethserver-httpd-admin-service

### DIFF
--- a/nethserver-docker.spec
+++ b/nethserver-docker.spec
@@ -9,6 +9,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  nethserver-devtools
 Requires:       docker-ce
+Requires: nethserver-httpd-admin-service
 
 %description
 NethServer configuration for Docker CE


### PR DESCRIPTION
following https://github.com/NethServer/dev/issues/6344 we need to require nethserver-httpd-admin-service to enable the service on the 980 TCP port

thank @markVnl