### PR TITLE
Filtering IPv6 addresses for shorewall as reported by docker 20.10.x …

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/50docker
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/50docker
@@ -23,8 +23,10 @@
 	    my ($port, $proto) = split(/\//, $k);
 
 	    foreach my $src (@{$bindings{$k}}) {
-                my $hostIp = $src->{'HostIp'} eq '0.0.0.0' ? '-' : $src->{'HostIp'};
-                $OUT .= "DNAT loc dock:" . $config->{'NetworkSettings'}->{'IPAddress'} . ":$port $proto " . $src->{'HostPort'} . " - $hostIp\n";
+                if (index($src->{'HostIp'},':') < 0) { # Ignoring IPv6 reported by docker (shorewall and Nethserver are IPv4 only!)
+                    my $hostIp = $src->{'HostIp'} eq '0.0.0.0' ? '-' : $src->{'HostIp'};
+                    $OUT .= "DNAT loc dock:" . $config->{'NetworkSettings'}->{'IPAddress'} . ":$port $proto " . $src->{'HostPort'} . " - $hostIp\n";
+                }
             }
         }
 	$OUT .= "\n";


### PR DESCRIPTION
So I recently upgraded portainer and docker-ce...in some time as it is only my private server here at home.
I discovered, that since then (so at least docker 20.10.6) the docker daemon reports exposed ports now including IPv6:
```
[root@srv ~]# docker ps
CONTAINER ID   IMAGE                                  COMMAND                  CREATED        STATUS         PORTS                                                                                  NAMES
d0a80c68a296   portainer/portainer-ce                 "/portainer"             3 days ago     Up 8 seconds   0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp   portainer
```
As this is included in the json output, the 50docker e-smith script extracts `::` as "ipv4 address" for a shorewall rule.
Because Nethserver much like shorewall do not support IPv6, the shorewall service does not come up - with all its dependencies:

`ERROR: Unknown Interface (::) /etc/shorewall/rules (line 74)`

Please considers my attempt to filtering this as attached.

Regards,
Jens

Edit: Issue created here: https://github.com/NethServer/dev/issues/6487

Signed-off-by: jenszo <6693266+jenszo@users.noreply.github.com>