### PR TITLE
Upgrade portainer to portainer-ce

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
+++ b/root/etc/e-smith/events/actions/nethserver-docker-create-portainer
@@ -54,5 +54,5 @@ docker run --detach \
     --hostname portainer \
     --network aqua \
     --ip ${IpAddress} \
-    portainer/portainer \
+    portainer/portainer-ce \
     -H unix:///var/run/docker.sock


### PR DESCRIPTION
The development of portainer has dicontinued to portainer-ce

There is a lot of changes like docker-compose and swarm support

If the sysadmin use portainer, the script ends, if portainer docker doesn't exist then we retrieve the image and build portainer-ce

The developers of portainer assumes the upgrade is fine between 1.24 to portainer-ce.

https://github.com/NethServer/dev/issues/6492